### PR TITLE
20200927, fix dataset readers

### DIFF
--- a/reader/hd1k.py
+++ b/reader/hd1k.py
@@ -23,7 +23,7 @@ def read_dataset(path = None, parts = 'mixed', resize = None, samples = -1, norm
 	dataset['occ'] = []
 	path_images = path['image']
 	path_flows = path['flow_occ']
-	list_files = os.listdir(path_flows)
+	list_files = sorted(os.listdir(path_flows))
 	num_files = len(list_files) - 1
 	ind_valids = VALIDATE_INDICES
 	num_valids = len(ind_valids)

--- a/reader/kitti.py
+++ b/reader/kitti.py
@@ -41,7 +41,7 @@ def read_dataset(path = None, editions = 'mixed', parts = 'mixed', crop = None, 
 		num_files = len(os.listdir(path_flows)) - 1
 		ind_valids = VALIDATE_INDICES[edition]
 		num_valids = len(ind_valids)
-		if samples is not None:
+		if samples is not -1:
 			num_files = min(num_files, samples)
 		ind = 0
 		for k in range(num_files):
@@ -96,7 +96,7 @@ def read_dataset_testing(path = None, editions = 'mixed', resize = None, samples
 	for edition in editions:
 		path_testing = path[edition + 'testing']
 		num_files = (len(os.listdir(path_testing)) - 1) // 2
-		if samples is not None:
+		if samples is not -1:
 			num_files = min(num_files, samples)
 		for k in range(num_files):
 			img0 = cv2.imread(os.path.join(path_testing, '%06d_10.png' % k))

--- a/reader/sintel.py
+++ b/reader/sintel.py
@@ -26,7 +26,7 @@ def list_data(path = None):
 				c = 0
 				dataset[part + str(1)][subset] = []
 				dataset[part + str(2)][subset] = []
-			for seq in os.listdir(os.path.join(path, part, subset)):
+			for seq in sorted(os.listdir(os.path.join(path, part, subset))):
 				frames = os.listdir(os.path.join(path, part, subset, seq))
 				frames = list(sorted(map(lambda s: int(pattern.match(s).group(1)),
 									 filter(lambda s: pattern.match(s), frames))))


### PR DESCRIPTION
'os.listdir' will return different results in different filesystems, add 'sorted()' to make sure the order.

Please refer to the issue here:
https://stackoverflow.com/questions/4813061/non-alphanumeric-list-order-from-os-listdir